### PR TITLE
fix modifier query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
     include:
         - php: 7.2
         - php: 7.3
-        - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-clover=coverage.clover"
     fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+env:
+    global:
+        - XDEBUG_MODE=coverage
+
 cache:
     directories:
         - $HOME/.composer/cache
@@ -8,6 +12,7 @@ matrix:
     include:
         - php: 7.2
         - php: 7.3
+        - php: 7.4
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-clover=coverage.clover"
     fast_finish: true
 

--- a/Action/CaptureAction.php
+++ b/Action/CaptureAction.php
@@ -10,7 +10,7 @@ use Karser\PayumSaferpay\Request\Api\CaptureTransaction;
 use Karser\PayumSaferpay\Request\Api\InitPaymentPage;
 use Karser\PayumSaferpay\Request\Api\InitTransaction;
 use League\Uri\Http as HttpUri;
-use League\Uri\Modifiers\MergeQuery;
+use League\Uri\UriModifier;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
 use Payum\Core\ApiAwareTrait;
@@ -135,17 +135,9 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface, Gateway
 
     private function composeReturnUrls(string $url): array
     {
-        $successUrl = HttpUri::createFromString($url);
-        $modifier = new MergeQuery('success=1');
-        $successUrl = $modifier->process($successUrl);
-
-        $failedUrl = HttpUri::createFromString($url);
-        $modifier = new MergeQuery('fail=1');
-        $failedUrl = $modifier->process($failedUrl);
-
-        $cancelUri = HttpUri::createFromString($url);
-        $modifier = new MergeQuery('abort=1');
-        $cancelUri = $modifier->process($cancelUri);
+        $successUrl = UriModifier::mergeQuery(HttpUri::createFromString($url), 'success=1');
+        $failedUrl = UriModifier::mergeQuery(HttpUri::createFromString($url), 'fail=1');
+        $cancelUri = UriModifier::mergeQuery(HttpUri::createFromString($url), 'abort=1');
 
         return [
             'Success' => (string) $successUrl,

--- a/Action/InsertCardAliasAction.php
+++ b/Action/InsertCardAliasAction.php
@@ -7,7 +7,7 @@ use Karser\PayumSaferpay\Request\Api\AssertInsertAlias;
 use Karser\PayumSaferpay\Request\Api\InsertAlias;
 use Karser\PayumSaferpay\Request\InsertCardAlias;
 use League\Uri\Http as HttpUri;
-use League\Uri\Modifiers\MergeQuery;
+use League\Uri\UriModifier;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\RequestNotSupportedException;
@@ -53,17 +53,9 @@ class InsertCardAliasAction implements ActionInterface, GatewayAwareInterface
         if (empty($model['ReturnUrls'])) {
             $token = $request->getToken();
 
-            $successUrl = HttpUri::createFromString($token->getTargetUrl());
-            $modifier = new MergeQuery('success=1');
-            $successUrl = $modifier->process($successUrl);
-
-            $failedUrl = HttpUri::createFromString($token->getTargetUrl());
-            $modifier = new MergeQuery('fail=1');
-            $failedUrl = $modifier->process($failedUrl);
-
-            $cancelUri = HttpUri::createFromString($token->getTargetUrl());
-            $modifier = new MergeQuery('abort=1');
-            $cancelUri = $modifier->process($cancelUri);
+            $successUrl = UriModifier::mergeQuery(HttpUri::createFromString($token->getTargetUrl()), 'success=1');
+            $failedUrl = UriModifier::mergeQuery(HttpUri::createFromString($token->getTargetUrl()), 'fail=1');
+            $cancelUri = UriModifier::mergeQuery(HttpUri::createFromString($token->getTargetUrl()), 'abort=1');
 
             $model['ReturnUrls'] = [
                 'Success' => (string) $successUrl,

--- a/Tests/Unit/Action/CaptureActionTest.php
+++ b/Tests/Unit/Action/CaptureActionTest.php
@@ -32,14 +32,12 @@ class CaptureActionTest extends GenericActionTest
         $this->assertTrue($rc->implementsInterface(GatewayAwareInterface::class));
     }
 
-    public function provideSupportedRequests(): array
+    public function provideSupportedRequests(): \Iterator
     {
         ($r1 = new Capture(new Token()))->setModel(array());
         ($r2 = new Capture(new Token()))->setModel(new \ArrayObject());
-        return [
-            [$r1],
-            [$r2],
-        ];
+
+        yield [[$r1], [$r2]];
     }
 
     /**

--- a/Tests/Unit/Action/CaptureActionTest.php
+++ b/Tests/Unit/Action/CaptureActionTest.php
@@ -37,7 +37,8 @@ class CaptureActionTest extends GenericActionTest
         ($r1 = new Capture(new Token()))->setModel(array());
         ($r2 = new Capture(new Token()))->setModel(new \ArrayObject());
 
-        yield [[$r1], [$r2]];
+        yield [$r1];
+        yield [$r2];
     }
 
     /**

--- a/Tests/Unit/Action/CaptureReferencedActionTest.php
+++ b/Tests/Unit/Action/CaptureReferencedActionTest.php
@@ -44,11 +44,9 @@ class CaptureReferencedActionTest extends GenericActionTest
     /**
      * Overridden because CaptureAction requires request to have TOKEN
      */
-    public function provideSupportedRequests(): array
+    public function provideSupportedRequests(): \Iterator
     {
-        return [
-            [new CaptureReferenced(new Payment())],
-        ];
+        yield [[new CaptureReferenced(new Payment())]];
     }
 
 }

--- a/Tests/Unit/Action/CaptureReferencedActionTest.php
+++ b/Tests/Unit/Action/CaptureReferencedActionTest.php
@@ -46,7 +46,7 @@ class CaptureReferencedActionTest extends GenericActionTest
      */
     public function provideSupportedRequests(): \Iterator
     {
-        yield [[new CaptureReferenced(new Payment())]];
+        yield [new CaptureReferenced(new Payment())];
     }
 
 }

--- a/Tests/Unit/Action/ConvertPaymentActionTest.php
+++ b/Tests/Unit/Action/ConvertPaymentActionTest.php
@@ -33,25 +33,24 @@ class ConvertPaymentActionTest extends GenericActionTest
         self::assertNotNull(new $this->actionClass());
     }
 
-    public function provideSupportedRequests()
+    public function provideSupportedRequests(): \Iterator
     {
-        return array(
-            array(new $this->requestClass(new Payment(), 'array')),
-            array(new $this->requestClass($this->createMock(PaymentInterface::class), 'array')),
-            array(new $this->requestClass(new Payment(), 'array', $this->createMock('Payum\Core\Security\TokenInterface'))),
-        );
+        yield [new $this->requestClass(new Payment(), 'array')];
+        yield [new $this->requestClass($this->createMock(PaymentInterface::class), 'array')];
+        yield [new $this->requestClass(new Payment(), 'array', $this->createMock('Payum\Core\Security\TokenInterface'))];
+
     }
-    public function provideNotSupportedRequests()
+
+    public function provideNotSupportedRequests(): \Iterator
     {
-        return array(
-            array('foo'),
-            array(array('foo')),
-            array(new \stdClass()),
-            array($this->getMockForAbstractClass(Generic::class, array(array()))),
-            array(new $this->requestClass(new \stdClass(), 'array')),
-            array(new $this->requestClass(new Payment(), 'foobar')),
-            array(new $this->requestClass($this->createMock(PaymentInterface::class), 'foobar')),
-        );
+        yield ['foo'];
+        yield [['foo']];
+        yield [new \stdClass()];
+        yield [$this->getMockForAbstractClass(Generic::class, [[]])];
+        yield [new $this->requestClass(new \stdClass(), 'array')];
+        yield [new $this->requestClass(new Payment(), 'foobar')];
+        yield [new $this->requestClass($this->createMock(PaymentInterface::class), 'foobar')];
+
     }
 
     /**

--- a/Tests/Unit/Action/InsertCardAliasActionTest.php
+++ b/Tests/Unit/Action/InsertCardAliasActionTest.php
@@ -42,7 +42,7 @@ class InsertCardAliasActionTest extends GenericActionTest
         self::assertNotNull(new $this->actionClass());
     }
 
-    public function provideSupportedRequests(): array
+    public function provideSupportedRequests(): \Iterator
     {
         function getRequest($details) {
             $alias = new CardAlias();
@@ -52,9 +52,6 @@ class InsertCardAliasActionTest extends GenericActionTest
             return $request;
         }
 
-        return [
-            [getRequest(array())],
-            [getRequest(new \ArrayObject())],
-        ];
+        yield [[getRequest([])], [getRequest(new \ArrayObject())]];
     }
 }

--- a/Tests/Unit/Action/InsertCardAliasActionTest.php
+++ b/Tests/Unit/Action/InsertCardAliasActionTest.php
@@ -52,6 +52,7 @@ class InsertCardAliasActionTest extends GenericActionTest
             return $request;
         }
 
-        yield [[getRequest([])], [getRequest(new \ArrayObject())]];
+        yield [getRequest([])];
+        yield [getRequest(new \ArrayObject())];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.2.0",
-        "payum/core": "^1.5"
+        "payum/core": "^1.6"
     },
     "require-dev": {
         "fabpot/goutte": "^3.3",


### PR DESCRIPTION
Payum requires league/uri 6 in its latest patch version (1.6.1) - which is not quite nice to do this in a patch release.

https://github.com/Payum/Core/commit/4273bd242add4cafe05c66ac186791612f03510b

Within league/uri 6 the modifiers package is not available anymore and it's time to adjust the query merger. 

This PR takes care about that.