### PR TITLE
feat: allow php8, bump phpunit 5 to 8

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
       fail-fast: false
     name: PHPUnit (PHP ${{ matrix.php }})
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # Composer files
 /composer.lock
 /vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
         }
     ],
     "require": {
-        "php": "^7.2.0",
+        "php": "^7.2 || ^8.0",
         "payum/core": "^1.6"
     },
     "require-dev": {
         "fabpot/goutte": "^3.3",
         "php-http/guzzle6-adapter": "^2.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
https://github.com/karser/PayumSaferpay/issues/10

phpunit5 had toString() errors (deprecations) so i had to update them to 8.
I changed one test. Please check that.

This needs to be merged first to run tests on travis
https://github.com/karser/PayumSaferpay/pull/11