### PR TITLE
bump minimum php version to 7.3

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.3', '7.4', '8.0', '8.1']
       fail-fast: false
     name: PHPUnit (PHP ${{ matrix.php }})
     steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here is how Transaction interface looks like:
 
 ## Requirements
 
-- PHP 7.2+
+- PHP 7.3+
 - [Payum](https://github.com/Payum/Payum)
 - Optionally [PayumBundle](https://github.com/Payum/PayumBundle) and Symfony 3 or 4+
 

--- a/Tests/Functional/CardAliasTest.php
+++ b/Tests/Functional/CardAliasTest.php
@@ -5,9 +5,12 @@ namespace Karser\PayumSaferpay\Tests\Functional;
 use Karser\PayumSaferpay\Constants;
 use Karser\PayumSaferpay\Request\Api\DeleteAlias;
 use Payum\Core\Reply\HttpRedirect;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 class CardAliasTest extends AbstractSaferpayTest
 {
+    use ArraySubsetAsserts;
+
     /**
      * @test
      */
@@ -33,8 +36,8 @@ class CardAliasTest extends AbstractSaferpayTest
         $iframeRedirect = $this->getThroughCheckout($reply->getUrl(), $formData = $this->composeFormData(self::CARD_SUCCESS, $cvc = false));
 
         self::assertStringStartsWith(self::HOST, $iframeRedirect);
-        self::assertContains('payum_token='.$token->getHash(), $iframeRedirect);
-        self::assertContains('success=1', $iframeRedirect);
+        self::assertStringContainsString('payum_token='.$token->getHash(), $iframeRedirect);
+        self::assertStringContainsString('success=1', $iframeRedirect);
         parse_str(parse_url($iframeRedirect, PHP_URL_QUERY), $_GET);
 
         $this->insertCardAlias($token, $cardAlias);

--- a/Tests/Functional/PaymentPageTest.php
+++ b/Tests/Functional/PaymentPageTest.php
@@ -58,7 +58,7 @@ class PaymentPageTest extends AbstractSaferpayTest
         $iframeRedirect = $this->getThroughCheckout($iframeUrl, $formData, $formBehavior);
 
         self::assertStringStartsWith(self::HOST, $iframeRedirect);
-        self::assertContains('payum_token='.$token->getHash(), $iframeRedirect);
+        self::assertStringContainsString('payum_token='.$token->getHash(), $iframeRedirect);
         parse_str(parse_url($iframeRedirect, PHP_URL_QUERY), $_GET);
 
         # AUTHORIZE AND CAPTURE
@@ -87,8 +87,8 @@ class PaymentPageTest extends AbstractSaferpayTest
         # submit form
         $iframeRedirect = $this->getThroughCheckout($iframeUrl, $this->composeFormData(self::CARD_SUCCESS));
         self::assertStringStartsWith(self::HOST, $iframeRedirect);
-        self::assertContains('payum_token='.$token->getHash(), $iframeRedirect);
-        self::assertContains('success=1', $iframeRedirect);
+        self::assertStringContainsString('payum_token='.$token->getHash(), $iframeRedirect);
+        self::assertStringContainsString('success=1', $iframeRedirect);
 
         $notifyUrl = $payment->getDetails()['Notification']['NotifyUrl'];
         $_SERVER['REQUEST_URI'] = $notifyUrl;

--- a/Tests/Functional/TransactionTest.php
+++ b/Tests/Functional/TransactionTest.php
@@ -64,7 +64,7 @@ class TransactionTest extends AbstractSaferpayTest
         $iframeRedirect = $this->getThroughCheckout($iframeUrl, $formData, $formBehavior);
         self::assertNotNull($iframeRedirect);
         self::assertStringStartsWith(self::HOST, $iframeRedirect);
-        self::assertContains('payum_token='.$token->getHash(), $iframeRedirect);
+        self::assertStringContainsString('payum_token='.$token->getHash(), $iframeRedirect);
         parse_str(parse_url($iframeRedirect, PHP_URL_QUERY) ?: '', $_GET);
 
         # AUTHORIZE AND CAPTURE

--- a/Tests/Unit/Action/Api/AuthorizeReferencedTransactionActionTest.php
+++ b/Tests/Unit/Action/Api/AuthorizeReferencedTransactionActionTest.php
@@ -16,35 +16,33 @@ class AuthorizeReferencedTransactionActionTest extends BaseApiActionTest
     /**
      * @test
      *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage Cannot authorize transaction with status: "FAILED"
      */
     public function throwIfStatusNotNull(): void
     {
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
+        $this->expectExceptionMessage("Cannot authorize transaction with status: \"FAILED\"");
         $action = new AuthorizeReferencedTransactionAction();
         $action->execute(new AuthorizeReferencedTransaction(['Transaction' => ['Status' => Constants::STATUS_FAILED]]));
     }
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage Payment is missing
      */
     public function throwIfPaymentNotSetInModel(): void
     {
+        $this->expectExceptionMessage("Payment is missing");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new AuthorizeReferencedTransactionAction();
         $action->execute(new AuthorizeReferencedTransaction(['Transaction' => ['Status' => null]]));
     }
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage TransactionId is missing
      */
     public function throwIfTransactionIdNotSetInModel(): void
     {
+        $this->expectExceptionMessage("TransactionId is missing");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new AuthorizeReferencedTransactionAction();
         $action->execute(new AuthorizeReferencedTransaction([
             'Payment' => ['set'],

--- a/Tests/Unit/Action/Api/AuthorizeTransactionActionTest.php
+++ b/Tests/Unit/Action/Api/AuthorizeTransactionActionTest.php
@@ -14,24 +14,22 @@ class AuthorizeTransactionActionTest extends BaseApiActionTest
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage Cannot authorize transaction with status: "FAILED"
      */
     public function throwIfStatusIncorrect(): void
     {
+        $this->expectExceptionMessage("Cannot authorize transaction with status: \"FAILED\"");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new AuthorizeTransactionAction();
         $action->execute(new AuthorizeTransaction(['Transaction' => ['Status' => Constants::STATUS_FAILED]]));
     }
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage Token is missing
      */
     public function throwIfTokenNotSetInModel(): void
     {
+        $this->expectExceptionMessage("Token is missing");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new AuthorizeTransactionAction();
         $action->execute(new AuthorizeTransaction(['Transaction' => ['Status' => Constants::STATUS_PENDING]]));
     }

--- a/Tests/Unit/Action/Api/BaseApiActionTest.php
+++ b/Tests/Unit/Action/Api/BaseApiActionTest.php
@@ -90,11 +90,10 @@ abstract class BaseApiActionTest extends TestCase
     }
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\RequestNotSupportedException
      */
     public function throwIfNotSupportedRequestGivenAsArgumentForExecute(): void
     {
+        $this->expectException(\Payum\Core\Exception\RequestNotSupportedException::class);
         $action = new $this->actionClass();
         $action->execute(new \stdClass());
     }

--- a/Tests/Unit/Action/Api/CaptureTransactionActionTest.php
+++ b/Tests/Unit/Action/Api/CaptureTransactionActionTest.php
@@ -14,24 +14,22 @@ class CaptureTransactionActionTest extends BaseApiActionTest
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage Cannot capture transaction with status: "FAILED"
      */
     public function throwIfStatusIncorrect(): void
     {
+        $this->expectExceptionMessage("Cannot capture transaction with status: \"FAILED\"");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new CaptureTransactionAction();
         $action->execute(new CaptureTransaction(['Transaction' => ['Status' => Constants::STATUS_FAILED]]));
     }
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage Transaction is missing
      */
     public function throwIfTransactionIdNotSetInModel(): void
     {
+        $this->expectExceptionMessage("Transaction is missing");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new CaptureTransactionAction();
         $action->execute(new CaptureTransaction(['Transaction' => ['Status' => Constants::STATUS_AUTHORIZED]]));
     }

--- a/Tests/Unit/Action/Api/InitTransactionActionTest.php
+++ b/Tests/Unit/Action/Api/InitTransactionActionTest.php
@@ -12,24 +12,22 @@ class InitTransactionActionTest extends BaseApiActionTest
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage Payment is missing
      */
     public function throwIfPaymentNotSetInModel()
     {
+        $this->expectExceptionMessage("Payment is missing");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new InitTransactionAction();
         $action->execute(new InitTransaction([]));
     }
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage ReturnUrls is missing
      */
     public function throwIfReturnsUrlNotSetInModel()
     {
+        $this->expectExceptionMessage("ReturnUrls is missing");
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
         $action = new InitTransactionAction();
         $action->execute(new InitTransaction(['Payment' => ['Amount' => 123]]));
     }
@@ -77,10 +75,10 @@ class InitTransactionActionTest extends BaseApiActionTest
 
     /**
      * @test
-     * @expectedException \Payum\Core\Reply\HttpRedirect
      */
     public function shouldThrowRedirect_ifSet()
     {
+        $this->expectException(\Payum\Core\Reply\HttpRedirect::class);
         $apiMock = $this->createApiMock();
         $action = new InitTransactionAction();
         $action->setApi($apiMock);

--- a/Tests/Unit/Action/ConvertPaymentActionTest.php
+++ b/Tests/Unit/Action/ConvertPaymentActionTest.php
@@ -9,9 +9,11 @@ use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Request\Convert;
 use Payum\Core\Request\Generic;
 use Payum\Core\Tests\GenericActionTest;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 class ConvertPaymentActionTest extends GenericActionTest
 {
+    use ArraySubsetAsserts;
     protected $requestClass = Convert::class;
     protected $actionClass = ConvertPaymentAction::class;
 

--- a/Tests/Unit/ApiTest.php
+++ b/Tests/Unit/ApiTest.php
@@ -12,9 +12,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Psr7\Response;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
 class ApiTest extends TestCase
 {
+    use ArraySubsetAsserts;
     private $options = [];
 
     public function setUp(): void
@@ -40,12 +42,11 @@ class ApiTest extends TestCase
 
     /**
      * @test
-     *
-     * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessageRegExp /fields are required/
      */
     public function throwIfSandboxOptionNotSetInConstructor(): void
     {
+        $this->expectException(\Payum\Core\Exception\LogicException::class);
+        $this->expectExceptionMessageMatches("/fields are required/");
         new Api(array(), $this->createHttpClientMock(), $this->createHttpMessageFactory());
     }
 
@@ -334,12 +335,11 @@ class ApiTest extends TestCase
 
     /**
      * @test
-     *
-     * @expectedException \Karser\PayumSaferpay\Exception\SaferpayHttpException
-     * @expectedExceptionMessage Condition 'WITH_LIABILITY_SHIFT' not satisfied
      */
     public function throwIfResponseStatusNotOk(): void
     {
+        $this->expectException(\Karser\PayumSaferpay\Exception\SaferpayHttpException::class);
+        $this->expectExceptionMessage("Condition 'WITH_LIABILITY_SHIFT' not satisfied");
         $clientMock = $this->createHttpClientMock();
         $clientMock
             ->expects($this->once())

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "payum/core": "^1.6"
     },
     "require-dev": {
-        "fabpot/goutte": "^3.3",
+        "fabpot/goutte": "^4.0",
         "php-http/guzzle6-adapter": "^2.0",
         "phpunit/phpunit": "^9.5",
         "dms/phpunit-arraysubset-asserts": "^0.4.0"

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,14 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "payum/core": "^1.6"
     },
     "require-dev": {
         "fabpot/goutte": "^3.3",
         "php-http/guzzle6-adapter": "^2.0",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.5",
+        "dms/phpunit-arraysubset-asserts": "^0.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true" bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>./Tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <directory>Tests</directory>
-                <directory>vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory>Tests</directory>
+      <directory>vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>./Tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Hi,

the usage of php 7.2 is at 0%.
See https://packagist.org/packages/karser/payum-saferpay/php-stats
With 7.3 we can move on to phpunit 9.

See https://github.com/sebastianbergmann/phpunit/issues/3494 for the reson of the new composer package.

Greetz