### PR TITLE
chore: fix ci deprecations

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3
@@ -64,7 +64,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3


### PR DESCRIPTION
Please check if correct.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/